### PR TITLE
Add site navigation bar

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css';
 import { ReactNode } from 'react';
+import NavBar from '../components/NavBar';
 
 export const metadata = {
   title: 'CuppaCrypto',
@@ -10,6 +11,7 @@ export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
       <body className="min-h-screen bg-gray-100 text-gray-900">
+        <NavBar />
         {children}
       </body>
     </html>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,6 @@
 export default function Home() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center p-8">
+    <main className="flex flex-col items-center justify-center p-8">
       <h1 className="text-4xl font-bold mb-4">Welcome to CuppaCrypto</h1>
       <p className="text-lg text-center max-w-xl">
         Brewed coffee meets blockchain. Buy fresh beans and gear with your favorite cryptocurrency.

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -1,0 +1,35 @@
+import Link from 'next/link';
+
+export default function NavBar() {
+  return (
+    <nav className="bg-white shadow">
+      <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4">
+        <div className="flex items-center space-x-6">
+          <Link href="/" className="text-xl font-bold">CuppaCrypto</Link>
+          <Link href="/" className="text-gray-700 hover:text-gray-900">Home</Link>
+          <Link href="/shop" className="text-gray-700 hover:text-gray-900">Shop</Link>
+          <Link href="/learn" className="text-gray-700 hover:text-gray-900">Learn</Link>
+          <Link href="/news" className="text-gray-700 hover:text-gray-900">News</Link>
+        </div>
+        <div className="flex items-center space-x-4">
+          <button aria-label="Search" className="text-gray-700 hover:text-gray-900">
+            <svg className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35M11 19a8 8 0 100-16 8 8 0 000 16z" />
+            </svg>
+          </button>
+          <button aria-label="Account" className="text-gray-700 hover:text-gray-900">
+            <svg className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
+              <path strokeLinecap="round" strokeLinejoin="round" d="M2 20a8 8 0 1116 0H2z" />
+            </svg>
+          </button>
+          <button aria-label="Cart" className="text-gray-700 hover:text-gray-900">
+            <svg className="h-5 w-5" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2 9m12-9l2 9M9 21a1 1 0 100-2 1 1 0 000 2zm8 0a1 1 0 100-2 1 1 0 000 2z" />
+            </svg>
+          </button>
+        </div>
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- add a responsive navigation bar with links for Home, Shop, Learn, and News
- include search, account, and cart icons in the navigation bar
- render the navigation bar across pages via the root layout and tidy the home page spacing

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4e97a8b0832686aeada1a7329576