### PR TITLE
fix: mark NavBar as client component

### DIFF
--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from 'next/link';
 import { useState } from 'react';
 


### PR DESCRIPTION
## Summary
- use client directive in NavBar to enable React hooks

## Testing
- `npm test`
- `npm run build` (fails: Module '@auth0/nextjs-auth0' has no exported member 'handleAuth')

------
https://chatgpt.com/codex/tasks/task_e_68ab6175db1c83269e06daf2a8ae49ae