### PR TITLE
Add informative route pages and tests

### DIFF
--- a/ENHANCEMENTS.md
+++ b/ENHANCEMENTS.md
@@ -1,0 +1,36 @@
+# Project Structure and Enhancement Guide
+
+This guide outlines the key parts of the project and how to extend it.
+
+## Project Structure
+
+- `app/` – Next.js App Router pages. Each subdirectory under `app` represents a route.
+- `components/` – Shared React components such as the navigation bar.
+- `__tests__/` – Jest unit tests for pages and components.
+- `prisma/` – Prisma schema and database migrations.
+- `pages/api/` – API routes for server-side functionality.
+
+## Navigating and Enhancing
+
+1. **Add a new page**
+   - Create a new folder inside `app/` with a `page.tsx` file.
+   - Include any components or content required for the route.
+   - Update navigation in `components/NavBar.tsx` if the page should be linked there.
+
+2. **Write tests**
+   - Add a corresponding test in `__tests__/` to ensure the page renders expected content.
+   - Run `npm test` to verify all tests pass.
+
+3. **Style and Components**
+   - Use Tailwind CSS utility classes for styling.
+   - Create reusable components in `components/` and import them where needed.
+
+4. **Data and Backend**
+   - Use Prisma models in `prisma/schema.prisma` for database work.
+   - API routes live under `pages/api/`.
+
+5. **Running and Building**
+   - `npm run dev` starts the development server.
+   - `npm run build` builds the production bundle.
+
+Following this structure helps maintain consistency and makes it easier to extend the application.

--- a/__tests__/home.test.tsx
+++ b/__tests__/home.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen } from '@testing-library/react';
 import Home from '../app/page';
 
-describe('Home', () => {
+describe('Home Page', () => {
   it('renders headline', () => {
     render(<Home />);
-    expect(screen.getByText(/CuppaCrypto/)).toBeInTheDocument();
+    expect(screen.getByText(/Welcome to CuppaCrypto/)).toBeInTheDocument();
   });
 });

--- a/__tests__/learn.test.tsx
+++ b/__tests__/learn.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import LearnPage from '../app/learn/page';
+
+describe('Learn Page', () => {
+  it('renders headline', () => {
+    render(<LearnPage />);
+    expect(screen.getByText(/Learn/)).toBeInTheDocument();
+  });
+});

--- a/__tests__/news.test.tsx
+++ b/__tests__/news.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import NewsPage from '../app/news/page';
+
+describe('News Page', () => {
+  it('renders headline', () => {
+    render(<NewsPage />);
+    expect(screen.getByText(/News/)).toBeInTheDocument();
+  });
+});

--- a/__tests__/shop.test.tsx
+++ b/__tests__/shop.test.tsx
@@ -1,0 +1,9 @@
+import { render, screen } from '@testing-library/react';
+import ShopPage from '../app/shop/page';
+
+describe('Shop Page', () => {
+  it('renders headline', () => {
+    render(<ShopPage />);
+    expect(screen.getByText(/Shop/)).toBeInTheDocument();
+  });
+});

--- a/app/learn/page.tsx
+++ b/app/learn/page.tsx
@@ -1,0 +1,10 @@
+export default function LearnPage() {
+  return (
+    <main className="flex flex-col items-center justify-center p-8">
+      <h1 className="text-4xl font-bold mb-4">Learn</h1>
+      <p className="text-lg text-center max-w-xl">
+        Dive into resources that explore the intersection of coffee culture and blockchain technology.
+      </p>
+    </main>
+  );
+}

--- a/app/news/page.tsx
+++ b/app/news/page.tsx
@@ -1,0 +1,10 @@
+export default function NewsPage() {
+  return (
+    <main className="flex flex-col items-center justify-center p-8">
+      <h1 className="text-4xl font-bold mb-4">News</h1>
+      <p className="text-lg text-center max-w-xl">
+        Stay up to date with the latest happenings in the worlds of caffeine and cryptocurrency.
+      </p>
+    </main>
+  );
+}

--- a/app/shop/page.tsx
+++ b/app/shop/page.tsx
@@ -1,0 +1,10 @@
+export default function ShopPage() {
+  return (
+    <main className="flex flex-col items-center justify-center p-8">
+      <h1 className="text-4xl font-bold mb-4">Shop</h1>
+      <p className="text-lg text-center max-w-xl">
+        Browse our selection of crypto-themed coffee beans and merchandise.
+      </p>
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- add Shop, Learn, and News pages with placeholder content
- expand Jest tests to cover each page
- document project structure and enhancement steps in ENHANCEMENTS.md

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab75cb29288326b46e928e7407e322