### PR TITLE
Add neon-themed navigation and home page body

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,7 +10,7 @@ export const metadata = {
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang="en">
-      <body className="min-h-screen bg-gray-100 text-gray-900">
+      <body className="min-h-screen bg-gradient-to-b from-black via-indigo-950 to-purple-900 text-fuchsia-100">
         <NavBar />
         {children}
       </body>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,11 +1,9 @@
+import HomeBody from '../components/HomeBody';
+
 export default function Home() {
   return (
-    <main className="flex flex-col items-center justify-center p-8">
-      <h1 className="text-4xl font-bold mb-4">Welcome to CuppaCrypto</h1>
-      <p className="text-lg text-center max-w-xl">
-        Brewed coffee meets blockchain. Buy fresh beans and gear with your favorite cryptocurrency.
-        Fueling you, and your trades.
-      </p>
+    <main>
+      <HomeBody />
     </main>
   );
 }

--- a/components/HomeBody.tsx
+++ b/components/HomeBody.tsx
@@ -1,0 +1,27 @@
+export default function HomeBody() {
+  return (
+    <section className="flex flex-col items-center bg-gradient-to-b from-black via-purple-950 to-indigo-950 text-fuchsia-100 py-16 px-4 space-y-10">
+      <div className="text-center space-y-4">
+        <h1 className="text-4xl font-bold drop-shadow-[0_0_0.3rem_#e879f9]">Welcome to CuppaCrypto</h1>
+        <p className="max-w-2xl text-lg">
+          Brewed coffee meets blockchain. Buy fresh beans and gear with your favorite cryptocurrency.
+          Fueling you, and your trades.
+        </p>
+      </div>
+      <div className="grid w-full max-w-5xl grid-cols-1 gap-8 md:grid-cols-3">
+        <div className="rounded-lg bg-indigo-900/40 p-6 shadow-lg">
+          <h3 className="mb-2 text-xl font-bold text-cyan-400">Arcane Beans</h3>
+          <p>Enchant your mornings with beans sourced from cryptic realms.</p>
+        </div>
+        <div className="rounded-lg bg-indigo-900/40 p-6 shadow-lg">
+          <h3 className="mb-2 text-xl font-bold text-cyan-400">Alchemy Gear</h3>
+          <p>Tools imbued with futuristic energy to brew the perfect cup.</p>
+        </div>
+        <div className="rounded-lg bg-indigo-900/40 p-6 shadow-lg">
+          <h3 className="mb-2 text-xl font-bold text-cyan-400">Blockchain Wisdom</h3>
+          <p>Unlock knowledge while sipping luminous lattes.</p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -1,185 +1,45 @@
 "use client";
 
 import Link from 'next/link';
-import { useState } from 'react';
+import { FaHome, FaShoppingBag, FaBookOpen, FaNewspaper, FaSearch, FaUser, FaShoppingCart } from 'react-icons/fa';
 
 export default function NavBar() {
-  const [menuOpen, setMenuOpen] = useState(false);
-
   return (
-    <nav className="w-full bg-white shadow">
-      <div className="mx-auto flex max-w-7xl items-center justify-between px-4 py-4">
-        <div className="flex items-center justify-between w-full md:w-auto">
-          <Link href="/" className="text-xl font-bold">
-            CuppaCrypto
+    <nav className="w-full bg-gradient-to-r from-indigo-950 via-purple-900 to-fuchsia-900 text-fuchsia-200 shadow-lg">
+      <div className="mx-auto flex max-w-7xl items-center justify-between p-4">
+        <Link href="/" className="text-2xl font-bold drop-shadow-[0_0_0.3rem_#e879f9]">
+          CuppaCrypto
+        </Link>
+        <div className="flex items-center space-x-6 text-lg">
+          <Link href="/" className="flex items-center gap-2 hover:text-cyan-300">
+            <FaHome />
+            <span className="hidden sm:inline">Home</span>
           </Link>
-          <button
-            className="ml-4 rounded-md p-2 text-gray-700 hover:bg-gray-100 hover:text-gray-900 focus:outline-none md:hidden"
-            aria-label="Toggle menu"
-            aria-expanded={menuOpen}
-            onClick={() => setMenuOpen(!menuOpen)}
-          >
-            {menuOpen ? (
-              <svg
-                className="h-6 w-6"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
-              </svg>
-            ) : (
-              <svg
-                className="h-6 w-6"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-              </svg>
-            )}
-          </button>
-        </div>
-
-        <div className="hidden items-center space-x-6 md:flex">
-          <Link href="/" className="text-gray-700 hover:text-gray-900">
-            Home
+          <Link href="/shop" className="flex items-center gap-2 hover:text-cyan-300">
+            <FaShoppingBag />
+            <span className="hidden sm:inline">Shop</span>
           </Link>
-          <Link href="/shop" className="text-gray-700 hover:text-gray-900">
-            Shop
+          <Link href="/learn" className="flex items-center gap-2 hover:text-cyan-300">
+            <FaBookOpen />
+            <span className="hidden sm:inline">Learn</span>
           </Link>
-          <Link href="/learn" className="text-gray-700 hover:text-gray-900">
-            Learn
-          </Link>
-          <Link href="/news" className="text-gray-700 hover:text-gray-900">
-            News
+          <Link href="/news" className="flex items-center gap-2 hover:text-cyan-300">
+            <FaNewspaper />
+            <span className="hidden sm:inline">News</span>
           </Link>
         </div>
-
-        <div className="hidden items-center space-x-4 md:flex">
-          <button aria-label="Search" className="text-gray-700 hover:text-gray-900">
-            <svg
-              className="h-5 w-5"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M21 21l-4.35-4.35M11 19a8 8 0 100-16 8 8 0 000 16z"
-              />
-            </svg>
+        <div className="flex items-center space-x-4 text-xl">
+          <button aria-label="Search" className="hover:text-cyan-300">
+            <FaSearch />
           </button>
-          <button aria-label="Account" className="text-gray-700 hover:text-gray-900">
-            <svg
-              className="h-5 w-5"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path strokeLinecap="round" strokeLinejoin="round" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z" />
-              <path strokeLinecap="round" strokeLinejoin="round" d="M2 20a8 8 0 1116 0H2z" />
-            </svg>
+          <button aria-label="Account" className="hover:text-cyan-300">
+            <FaUser />
           </button>
-          <button aria-label="Cart" className="text-gray-700 hover:text-gray-900">
-            <svg
-              className="h-5 w-5"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2"
-              viewBox="0 0 24 24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2 9m12-9l2 9M9 21a1 1 0 100-2 1 1 0 000 2zm8 0a1 1 0 100-2 1 1 0 000 2z"
-              />
-            </svg>
+          <button aria-label="Cart" className="hover:text-cyan-300">
+            <FaShoppingCart />
           </button>
         </div>
       </div>
-
-      {menuOpen && (
-        <div className="space-y-2 px-4 pb-4 md:hidden">
-          <Link href="/" className="block rounded-md px-2 py-1 text-gray-700 hover:bg-gray-100">
-            Home
-          </Link>
-          <Link href="/shop" className="block rounded-md px-2 py-1 text-gray-700 hover:bg-gray-100">
-            Shop
-          </Link>
-          <Link href="/learn" className="block rounded-md px-2 py-1 text-gray-700 hover:bg-gray-100">
-            Learn
-          </Link>
-          <Link href="/news" className="block rounded-md px-2 py-1 text-gray-700 hover:bg-gray-100">
-            News
-          </Link>
-          <div className="flex space-x-4 pt-2">
-            <button aria-label="Search" className="text-gray-700 hover:text-gray-900">
-              <svg
-                className="h-5 w-5"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M21 21l-4.35-4.35M11 19a8 8 0 100-16 8 8 0 000 16z"
-                />
-              </svg>
-            </button>
-            <button aria-label="Account" className="text-gray-700 hover:text-gray-900">
-              <svg
-                className="h-5 w-5"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"
-                />
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M2 20a8 8 0 1116 0H2z"
-                />
-              </svg>
-            </button>
-            <button aria-label="Cart" className="text-gray-700 hover:text-gray-900">
-              <svg
-                className="h-5 w-5"
-                fill="none"
-                stroke="currentColor"
-                strokeWidth="2"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2 9m12-9l2 9M9 21a1 1 0 100-2 1 1 0 000 2zm8 0a1 1 0 100-2 1 1 0 000 2z"
-                />
-              </svg>
-            </button>
-          </div>
-        </div>
-      )}
     </nav>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "next": "^15.5.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-icons": "^5.5.0",
         "stripe": "^18.4.0"
       },
       "devDependencies": {
@@ -6780,6 +6781,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.1"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "next": "^15.5.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-icons": "^5.5.0",
     "stripe": "^18.4.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Create HomeBody component with placeholder content and neon styling.
- Replace text links with icon-based horizontal navbar using react-icons and mystical neon gradient.
- Update layout to dark neon theme and add react-icons dependency.

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68abc5aad0348326aac30d1f8df4409e